### PR TITLE
Changes for PTR-BCR-2

### DIFF
--- a/everything_else/reproducing.m
+++ b/everything_else/reproducing.m
@@ -155,6 +155,13 @@ LHS = b1.*b2.*b3.*b4;
 RHS = 1/2*(b1 + b2 + b3 + b4 - 2*ba1).*(b1 + b2 + b3 + b4 - 2*ba1 - 1);
 
 %% Pg. 21, PTR-BCR-2
+
+b = dec2bin(2^6-1:-1:0)-'0';
+b1=b(:,1);b2=b(:,2);b3=b(:,3);b4=b(:,4);ba1=b(:,5);ba2=b(:,6);
+LHS = min(reshape (b1.*b2.*b3.*b4,2,[]));
+RHS = min(reshape (1/2*(4 + b1 + b2 + b3 + b4 - ba1 - 2.*ba2).*(3 + b1 + b2 + b3 + b4 - ba1 - 2.*ba2),2,[]));
+isequal(LHS,RHS);
+
 %% Pg. 22, PTR-BCR-3 (example appears to be the same as PTR-BCR-1, and may have to be redone)
 %% Pg. 23, PTR-BCR-4 
 %% Pg. 24, PTR-KZ (needs an example!)


### PR DESCRIPTION
Added in the following proof for PTR-BCR-2:


%% Pg. 21, PTR-BCR-2

b = dec2bin(2^6-1: -1:0)-'0';
b1=b(:,1);b2=b(:,2);b3=b(:,3);b4=b(:,4);ba1=b(:,5);ba2=b(:,6);
LHS = min(reshape (b1.*b2.*b3.*b4,2,[]));
RHS = min(reshape (1/2*(4 + b1 + b2 + b3 + b4 - ba1 - 2.*ba2).*(3 + b1 + b2 + b3 + b4 - ba1 - 2.*ba2),2,[]));
isequal(LHS,RHS);